### PR TITLE
Préciser la langue d'un billet en langue anglaise

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -2,7 +2,7 @@
 layout: default
 ---
 
-<article class="main">
+<article class="main" {% if page.lang %}lang="{page.lang}"{% endif %}>
   <header>
     <ul>
       <li class="date">


### PR DESCRIPTION
Afin de mieux référencer les articles en anglais, la langue de l'article est indiquée

### Test d'acceptance

Lorsque un moteur de rechercher indexe la page https://nicolas-hoizey.com/2016/03/people-don-t-change-the-default-16px-font-size-in-their-browser.html
Alors la présence d'un attribut `lang` indique que l'article est en anglais

### Implémentation basique

- [x] ajouter une variable Front-Matter dans l'entête des posts en anglais

```
lang: en
```

- [x] Si la variable lang est présente, alors on insère la balise `lang` au niveau de l'article.