### PR TITLE
add appearance: none to search input

### DIFF
--- a/_assets/stylesheets/critical-styles.scss
+++ b/_assets/stylesheets/critical-styles.scss
@@ -498,6 +498,7 @@ article {
   [type=search] {
     flex: 1;
     border: 2px solid #ccc;
+    -webkit-appearance: none;
 
     &:focus {
       border: 2px solid $color-purple-heart;


### PR DESCRIPTION
this doesn't always get picked up by autoprefixer, so I wrote it with the prefix. 

This makes the search box look like intended on Safari