### PR TITLE
Propose WebM first or else the browser will not use it

### DIFF
--- a/_posts/2018/08/01-using-cloudinary-s-fetch-api-to-convert-an-animated-gif-to-a-video/2018-08-01-using-cloudinary-s-fetch-api-to-convert-an-animated-gif-to-a-video.md
+++ b/_posts/2018/08/01-using-cloudinary-s-fetch-api-to-convert-an-animated-gif-to-a-video/2018-08-01-using-cloudinary-s-fetch-api-to-convert-an-animated-gif-to-a-video.md
@@ -72,8 +72,8 @@ With this:
 
 ```html
 <video autoplay loop muted playsinline>
-  <source src="https://res.cloudinary.com/<cloud_name>/image/fetch/f_mp4/https://example.com/anim.gif" type="video/mp4">
   <source src="https://res.cloudinary.com/<cloud_name>/image/fetch/f_webm/https://example.com/anim.gif" type="video/webm">
+  <source src="https://res.cloudinary.com/<cloud_name>/image/fetch/f_mp4/https://example.com/anim.gif" type="video/mp4">
   <p>Your browser doesn't support HTML5 video, <a href="https://example.com/anim.gif">download the animated GIF</a>.</p>
 </video>
 ```


### PR DESCRIPTION
Browsers don't speculate about which `<source>` is optimal, so the order
of `<source>`s matters. If you specify an MPEG-4 video first and
the browser supports WebM, browsers will skip the WebM `<source>` and use the
MPEG-4 instead. If you prefer a WebM `<source>` be used first, _specify it
first!_